### PR TITLE
Update tag filters for new snapshot format

### DIFF
--- a/.github/workflows/new_release.yaml
+++ b/.github/workflows/new_release.yaml
@@ -1,5 +1,12 @@
 name: New Release
 
+# Creates a GitHub Release on this SPM mirror repo whenever a stable or
+# pre-release tag (alpha / beta / rc) is pushed by the upstream
+# `nexmoclient-sdk-core-kmp` publish pipeline. Snapshot tags
+# (`v*-snapshot.YYYYMMDDHHmm`) deliberately don't match any include
+# below, so SPM gets the tag for resolution but no GitHub Release is
+# cut — snapshots are not customer-announced events.
+
 permissions:
   contents: write
 
@@ -10,7 +17,6 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+
       - v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+
       - v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+
-      - '!v[0-9]+.[0-9]+.[0-9]+-snapshot.[0-9]+.0'
 
 jobs:
   new_release:
@@ -18,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           body: https://developer.vonage.com/en/vonage-client-sdk/release-notes
           prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
## Summary

Updates the tag filter list to match the new snapshot tag format from the upstream `nexmoinc/nexmoclient-sdk-core-kmp` repo (see [nexmoinc/nexmoclient-sdk-core-kmp#975](https://github.com/nexmoinc/nexmoclient-sdk-core-kmp/pull/975)).

## Context

This SPM mirror repo's `new_release.yaml` cuts a GitHub Release whenever a customer-facing tag is pushed by the upstream Publish pipeline. The triggers were:

```yaml
- v[0-9]+.[0-9]+.[0-9]+
- v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+
- v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+
- v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+
- '!v[0-9]+.[0-9]+.[0-9]+-snapshot.[0-9]+.0'
```

The exclusion line targets the legacy `{base}-snapshot.{run_number}.0` format produced by the pre-trunk `release.yml`. That format died with the trunk-based migration; the new format is `{base}-snapshot.{YYYYMMDDHHmm}` (UTC, minute precision).

The new format doesn't match any of the include patterns either, so snapshot tag pushes already silently produce no GitHub Release on this mirror — which is the correct behaviour (snapshots are dev-internal, not customer-announced events). The exclusion line is dead code defending against a format that won't be produced.

## Change

```diff
       - v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+
-      - '!v[0-9]+.[0-9]+.[0-9]+-snapshot.[0-9]+.0'
```

Plus a couple of low-risk action version bumps while we're touching the file:

- `actions/checkout` v3 → v4 (v3 is deprecated, emits warnings)
- `softprops/action-gh-release` v1 → v2

## Behaviour

| Tag pushed | Before | After |
|---|---|---|
| `v2.4.0` | Release created | Release created |
| `v2.4.0-alpha.5` | Release created (prerelease) | Release created (prerelease) |
| `v2.4.0-snapshot.202606231500` (new format) | No release | No release |
| `v1.3.0-snapshot.51.0` (legacy format) | No release | No release |

No behaviour change for stable or pre-release tag pushes.

## Why this needs to land first

The upstream PR (#975) is about to start cutting snapshot tags using the new format to validate the end-to-end release pipeline. The current state of this workflow is harmless but misleading — anyone reading it sees a defensive line against a non-existent format and wonders if there's a bug.

## Test plan

- [x] YAML lint
- [ ] After merge: validate by triggering an upstream snapshot publish (runs in `nexmoinc/nexmoclient-sdk-core-kmp`)
